### PR TITLE
feat: enhance dependencyKeys handling to include function arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ users = await cachedGetUsers(); // <-- This will be executed and cached
 
 You can pass an additional parameter `dependencyKeys` property which instructs the plugin about which keys to use to invalidate the cache records if necessary.  
 This property can be either a number, a string, an array of strings, a function that returns an array of strings or a function that returns a Promise fulfilled with an array of strings.  
-Both the function and the Promise will receive the result of the method on which the `cacheCandidate` operates.  
+Both the function and the Promise will receive the result of the method on which the `cacheCandidate` operates as the first argument and the function arguments as the second argument (`fnArgs`).   
 In case of an async method, the promise will be fulfilled before passing the result to the `dependencyKeys` function.  
 The `dependencyKeys` function will be called only if the cache adapter correctly sets the value in the cache (i.e. the `.set` method is fulfilled).

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -20,7 +20,8 @@ export const PluginDependencyKeys: CacheCandidatePlugin = {
         let dependencyKeys: any = additionalParameters.dependencyKeys;
         dependencyKeys = await remapDependencyKeys(
           dependencyKeys,
-          payload.result
+          payload.result,
+          payload.fnArgs
         );
         cacheCandidateDependencyManager.register(
           payload,
@@ -36,9 +37,9 @@ export const PluginDependencyKeys: CacheCandidatePlugin = {
   ]
 };
 
-async function remapDependencyKeys(dependencyKeys: any, result: unknown) {
+async function remapDependencyKeys(dependencyKeys: any, result: unknown, fnArgs: unknown[]) {
   if (typeof dependencyKeys === 'function') {
-    dependencyKeys = dependencyKeys(result);
+    dependencyKeys = dependencyKeys(result, fnArgs);
     if (dependencyKeys instanceof Promise) {
       dependencyKeys = await dependencyKeys;
     }


### PR DESCRIPTION
This pull request updates how the `dependencyKeys` property works in the cache plugin, ensuring that both the result of the cached function and its arguments (`fnArgs`) are passed to the `dependencyKeys` function. This makes cache invalidation more flexible and accurate. The changes also add a corresponding test to verify this new behavior.

### Improvements to cache plugin API:

* Updated the logic in `remapDependencyKeys` and its usage so that the `dependencyKeys` function now receives both the result and the function arguments (`fnArgs`) as parameters, allowing for more context-aware cache key generation. (`src/plugin.ts`, [[1]](diffhunk://#diff-57716bc53661ccdb4571d571f1a5493294848965ae6068dbb3d9a1167d2cc1a6L23-R24) [[2]](diffhunk://#diff-57716bc53661ccdb4571d571f1a5493294848965ae6068dbb3d9a1167d2cc1a6L39-R42)
* Clarified documentation in `README.md` to specify that `dependencyKeys` receives the result as the first argument and function arguments as the second argument.

### Test coverage:

* Added a new test to ensure that the `dependencyKeys` function receives the correct arguments (`result` and `fnArgs`), and that cache keys are registered appropriately. (`src/index.test.ts`, [src/index.test.tsR155-R186](diffhunk://#diff-258035e5968f6bf645400d417f310218d7d9a9a10606a3c34e7f55db193f58f3R155-R186))